### PR TITLE
Enable rename-dependency unstable cargo feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,5 @@
+cargo-features = ["rename-dependency"]
+
 [package]
 name = "uefi-run"
 description = "Run UEFI applications"


### PR DESCRIPTION
Hi, thanks for creating this!

Installing uefi-run on my laptop failed with the included error message.
Using this small one line fix it works again but ties it to rust nightly (if it was not already dependent on it).

Feel free to reject/ignore this proposal if you don't want this change or there exists a better solution :)

```sh
$ cargo install uefi-run
    Updating crates.io index
  Installing uefi-run v0.3.2
error: failed to compile `uefi-run v0.3.2`, intermediate artifacts can be found at `/tmp/cargo-installi5YlZG`

Caused by:
  unable to get packages from source

Caused by:
  failed to parse manifest at `/home/llandsmeer/.cargo/registry/src/github.com-1ecc6299db9ec823/rand-0.7.0/Cargo.toml`

Caused by:
  feature `rename-dependency` is required

consider adding `cargo-features = ["rename-dependency"]` to the manifest
 -> 101

$ cargo --version
cargo 1.31.0-nightly (2d0863f65 2018-10-20)

$ lsb_release -a
No LSB modules are available.
Distributor ID: Ubuntu
Description:    Ubuntu 18.04.2 LTS
Release:        18.04
Codename:       bionic
$ uname -a
Linux a7 4.15.0-52-generic #56-Ubuntu SMP Tue Jun 4 22:49:08 UTC 2019 x86_64 x86_64 x86_64 GNU/Linux
```
