### PR TITLE
Add ability for users to include arbitrary files within the EFI partition

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -62,7 +62,8 @@ fn main() {
                 )
                 .multiple(true)
                 .short("f")
-                .long("add-file").number_of_values(1),
+                .long("add-file")
+                .number_of_values(1),
         )
         .arg(
             clap::Arg::with_name("qemu_args")


### PR DESCRIPTION
#### Edit: Focus of this PR has changed since it was created, the old description can be seen below

This PR adds the ability for users to include arbitrary files within the FAT image file created. This functionality is controlled with the `--add_files <location_on_disk>:<location_within_image>` argument.
This flag can be supplied  multiple times to include multiple files, and the `<location_within_image>` can be excluded (eg: `--add_file <location_on_disk>`) to have the file be placed at the root of the image with the name of the exterior file.


#### Old Description

Converted the startup method for the .efi app from a 'startup.nsh' script into a boot entry saved in non-volatile ram (NvVars file)
This method has the benefit of not having a 5 second wait at the start of every boot cycle

The steps required to create the NvVars serialised binary file which contains the run.efi file as boot 0 are
- Start uefi-run with a standard .efi file to create an image.fat file
	- `$ uefi-run /Path/To/.efi`
- Copy the image.fat file from the temporary directory and save it somewhere else, (your image.fat may not be stored in this dir, it depends on where the tempfile crate puts temp files on your system)
	- `$ cp /tmp/.tmp######/image.fat /Path/To/image.fat`
- Close uefi-run and start a qemu session with the following command, these steps are done to create a persistent session that we can extract the NvVars file from
	- `$ qemu-system-x86_64 -bios /usr/share/ovmf/OVMF.fd -net none -drive file=/Path/To/image.fat,index=0,media=disk,format=raw`
- Once qemu launched, press escape to stop the auto-startup
- Inside the uefi shell, type the following command, this command will create the boot option, set it to priority 0, and save it to the NvVars file (It is saved to a file as this is the backup system uefi uses when a system does not support non-volatile ram)
	- `Shell> bcfg boot add 0 FS0:\run.efi "uefi_boot"`
- Close qemu
- Mount the image.fat file to a directory (this step requires root access)
	- `$ mkdir /Path/To/Temp/Dir`
	- `# mount /Path/To/image.fat /Path/To/Temp/Dir`
- Navigate to the mounted image.fat filesystem
	- `$ cd /Path/To/Temp/Dir`
- Copy the 'NvVars' file out to a safe location
	- `$ cp ./NvVars /Path/To/Somewhere/Safe`
- You can now unmount the image.fat and delete the temp dir (this step requires root access)
	- `# umount /Path/To/Temp/Dir`
	- `$ rmdir /Path/To/Temp/Dir`