### PR TITLE
Build the snap package during regular CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,22 +66,20 @@ jobs:
   publish_snap:
     runs-on: ubuntu-latest
     if: ${{ github.ref == 'refs/heads/master' }}
-    needs: [build, clippy, format]
+    needs: [build, build_snap, clippy, format]
     steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-
-      - name: Install snapcraft
-        uses: samuelmeuli/action-snapcraft@v1
+      - name: Download Snap Artifact
+        uses: actions/download-artifact@v2
         with:
-          use_lxd: true
-          snapcraft_token: ${{ secrets.snapcraft_token }}
+          name: snap
 
-      - name: Install review tools
-        run: sudo snap install review-tools
-
-      - name: Build snap
-        run: sg lxd -c 'snapcraft --use-lxd'
+      - name: Get snap filename
+        id: get_filename
+        run: 'echo ::set-output name=filename::$(ls *.snap)'
 
       - name: Publish snap
-        run: snapcraft upload ./uefi-run_*.snap --release edge
+        uses: snapcore/action-publish@v1
+        with:
+          store_login: ${{ secrets.SNAPSTORE_LOGIN }}
+          snap: ${{ steps.get_filename.outputs.filename }}
+          release: edge

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,22 @@ jobs:
       - name: Run tests
         run: cargo test --verbose
 
+  build_snap:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Snapcraft
+        id: snapcraft
+        uses: snapcore/action-build@v1
+
+      - name: Upload Snap Artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: snap
+          path: ${{ steps.snapcraft.outputs.snap }}
+
   clippy:
     runs-on: ubuntu-latest
     steps:

--- a/bors.toml
+++ b/bors.toml
@@ -2,6 +2,7 @@ status = [
 	"build (ubuntu-latest)",
 	"build (macOS-latest)",
 	"build (windows-latest)",
+	"build_snap",
 	"clippy",
 	"format",
 ]


### PR DESCRIPTION
This adds the `build_snap` job to the regular CI workflow. It also attempts to fix the `publish_snap` stage that is currently broken on master.