### PR TITLE
Bypass 5 second delay

### DIFF
--- a/src/args.rs
+++ b/src/args.rs
@@ -31,6 +31,9 @@ pub struct Args {
     pub efi_exe: String,
     /// Additional arguments for qemu
     pub qemu_args: Vec<String>,
+    /// Skip the 5 second delay and start directly
+    #[clap(long, short = 'd')]
+    pub boot: bool,
 }
 
 impl Args {

--- a/src/main.rs
+++ b/src/main.rs
@@ -38,10 +38,13 @@ fn main() {
         let mut image =
             EfiImage::new(&image_file_path, args.size * 0x10_0000).expect("Failed to create image");
 
-        // Create run.efi
-        image
-            .copy_host_file(&args.efi_exe, "run.efi")
-            .expect("Failed to copy EFI executable");
+        // Create EFI executable
+        if args.boot {
+            image.copy_host_file(&args.efi_exe, "EFI/Boot/BootX64.efi")
+        } else {
+            image.copy_host_file(&args.efi_exe, "run.efi")
+        }
+        .expect("Failed to copy EFI executable");
 
         // Create startup.nsh
         image


### PR DESCRIPTION
In fact, if you rename the efi file that needs to be executed to `EFI/Boot/BootX64.efi`, you can solve the problem that there will be a 5-second delay at startup. In this case, `startup.nsh` is unnecessary .