### PR TITLE
support persistent data/mount

### DIFF
--- a/src/args.rs
+++ b/src/args.rs
@@ -36,6 +36,9 @@ pub struct Args {
     /// This effectively skips the 5 second startup delay.
     #[clap(long, short = 'd')]
     pub boot: bool,
+    /// Mount a persistent store which may be used by OVMF to store non-volatile variables
+    #[clap(long, short = 'p')]
+    pub persistent: bool,
 }
 
 impl Args {

--- a/src/main.rs
+++ b/src/main.rs
@@ -73,6 +73,29 @@ fn main() {
         .additional_args
         .extend(args.qemu_args.iter().cloned());
 
+    // Prepare persistent mount
+    if args.persistent {
+        let persistent_image_path = {
+            let mut base = std::env::home_dir().unwrap_or(PathBuf::from("/"));
+            base.push(".uefi-run.persistent.fat");
+            base
+        };
+
+        if !persistent_image_path.exists() {
+            EfiImage::new(&persistent_image_path, 0x40_0000)
+                .expect("Failed to create persistent image");
+        }
+
+        qemu_config.drives.insert(
+            0,
+            QemuDriveConfig {
+                file: persistent_image_path.to_str().unwrap().to_string(),
+                media: "disk".to_string(),
+                format: "raw".to_string(),
+            },
+        )
+    }
+
     // Run qemu
     let mut qemu_process = qemu_config.run().expect("Failed to start qemu");
 


### PR DESCRIPTION
This small change introduces an option to mount a persistent drive, i.e. one that is not always created from scratch in a temporary location. This drive can be used to store persistent data across multiple boots (or tool invocations).

For example, the OVMF stores its non-volatile variables in a binary file called `NvVars` on the first mounted disk.

---
I've picked `.uefi-run.persistent.fat` to be stored in the user `$HOME`. Not sure whether that's the best location, but at least it should always be available. Hopefully, `4 MiB` are enough.